### PR TITLE
Sim documentation for mtl manual

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+My GitHub Page

--- a/sim_ui.md
+++ b/sim_ui.md
@@ -5,13 +5,55 @@
 2. [mtl.how/facilitate](https://mtl.how/facilitate)
 
 ## Background
-The *Modeling to Learn* simulation user-interface is used in *Modeling to Learn Blue* Sessions 5-10 to run simulation experiments of the frontline team's operations and coordination. The facilitator helps each team decides on a module during Session 4 using the *Modeling to Learn* Menu based on the team's needs and highest priorities. The team can choose from 5 modules: Care Coordination, Medication Management, Psychotherapy, Aggregate Mix of Services, and Measurement Based Care and Suicide Prevention. runs 4 scenarios - basecase of no new decisions, experiment 1, experiment 2, and experiment 3.
+The *Modeling to Learn* simulation user-interface is used in *Modeling to Learn Blue* Sessions 5-10 to run simulation experiments of the frontline team's operations and coordination. The co-facilitators helps each team decide on a module during Session 4 using the *Modeling to Learn* Menu based on the team's needs and highest priorities. 
 
-- sessions 5-10 run experiments
-- run basecase, experiment 1, experiment 2, and experiment 3 all in one module
-- 5 modules determined by MTL menu in session 4
-- have individual worlds for playing around in and team worlds for sessions
-- all based on VA email login
+The team can choose from 5 modules: Care Coordination, Medication Management, Psychotherapy, Aggregate Mix of Services, and Measurement Based Care and Suicide Prevention. Over the course of *MTL*, the team runs 4 scenarios relevant to their care team's operations - basecase of no new decisions, experiment 1, experiment 2, and experiment 3.
+
+## Simulation User-Interface
+Using their VA email, clinicians can login to two types of environments on the simulation user-interface, or sim UI: team world and individual world. There is one team world per team which includes all members of the care team as well as the co-facilitators for making team decisions to run experiments together. There is one individual world per team member for running extra experiments on their own.
+
+The sim UI also includes the following navigation icons:
+- Chat
+- More Info
+- News
+- Report Bug
+- Tutor 
+- Community
+
+
+Click on the "Team" icon to chat with your team or facilitator.
+
+Click on the "More Info" icon for more info on the sim UI.
+
+Click on the "News" icon for news flashes on discussion items. Your input on discussion items in the Community of Practice is appreciated. A red pop-up with a number will appear next to this icon (similar to how text messages work on your phone) to alert you to the number of un-read news flashes. Once you read the news flashes, the red pop-up will disappear, but you can always click on "News" to review the current new flashes.
+
+Click on the "Report Bug" Icon in the top nav bar to report issues.
+
+Never include any PII/PHI in your description and screenshot.
+To include screenshots, you can:
+Copy & paste from Snipping Tool
+Drag & drop a screenshot file
+Upload your screenshot file
+Click on the "Tutor" icons for an "over the shoulder" orientation to the different icons, blue headers, and functions of each page. Each red tutor pop-up includes icons for:
+
+Video: Links to the relevant TMS video for this section.
+Guide: Links to the relevant session guide for this section.
+Back/Next: Move back or next in the tutor instructions for this section.
+Close: Close the tutor pop-up. Click on any tutor icon at any time, to get "over the shoulder" instructions for this section.
+Click on the "Community" button on the bottom right if:
+
+You have an idea
+You like something
+You have a question:
+See if someone already answered your question online in the Community of Practice.
+Set up a GitHub account to ask your question directly in the Community of Practice.
+Email your question to mtl.help@va.gov
+Never include any PII/PHI in your description and screenshot unless you are emailing mtl.help@va.gov from your VA email. The Community of Practice is a public platform. Follow established VA guidance on posting information to the public.
+To include screenshots in the "Community" button, you can:
+Copy & paste from Snipping Tool
+Drag & drop a screenshot file
+Upload your screenshot file
+
 - includes tutor function
 - includes function to chat with team or facilitator during live session
 - stay up to date with new ideas & questions posed in community of practice

--- a/sim_ui.md
+++ b/sim_ui.md
@@ -1,0 +1,54 @@
+# *Modeling to Learn* Simulation User-Interface and Forio Epicenter Backend Management
+
+### Relevant Shortlinks
+1. [mtl.how/sim](https://mtl.how/sim)
+2. [mtl.how/facilitate](https://mtl.how/facilitate)
+
+## Background
+The *Modeling to Learn* simulation user-interface is used in *Modeling to Learn Blue* Sessions 5-10 to run simulation experiments of the frontline team's operations and coordination. The facilitator helps each team decides on a module during Session 4 using the *Modeling to Learn* Menu based on the team's needs and highest priorities. The team can choose from 5 modules: Care Coordination, Medication Management, Psychotherapy, Aggregate Mix of Services, and Measurement Based Care and Suicide Prevention. runs 4 scenarios - basecase of no new decisions, experiment 1, experiment 2, and experiment 3.
+
+- sessions 5-10 run experiments
+- run basecase, experiment 1, experiment 2, and experiment 3 all in one module
+- 5 modules determined by MTL menu in session 4
+- have individual worlds for playing around in and team worlds for sessions
+- all based on VA email login
+- includes tutor function
+- includes function to chat with team or facilitator during live session
+- stay up to date with new ideas & questions posed in community of practice
+- contribute to ideas questions, in community of practice
+- submit bugs 
+
+- each team managed in backend
+- holds all model files
+- explain dev/test/prod
+- add learners
+- add facilitators
+- get login for new facilitator
+- team world management and naming
+- create groups & roles
+- chnage role to facilitator
+- manage end users
+- edit more info
+- edit quick tips
+- edit tutor
+- facilitator dashboard
+- pldr stuff
+- chat with team
+- 
+## Maps
+- run an experiment
+- add avatar
+- upload new file to run in sim
+- manage experiments
+- create groups/worlds and add learners
+- suppress world
+- change world to facilitator
+- edit more info
+- edit quick tips
+- anything facilitator world related
+
+## Cheatsheets
+- sim ui checklist
+
+## Checklists
+- pre session run through to make sure everything is working for team

--- a/sim_ui.md
+++ b/sim_ui.md
@@ -13,6 +13,7 @@ The team can choose from 5 modules: Care Coordination, Medication Management, Ps
 Using their VA email, clinicians can login to two types of environments on the simulation user-interface, or sim UI: team world and individual world. There is one team world per team which includes all members of the care team as well as the co-facilitators for making team decisions to run experiments together. There is one individual world per team member for running extra experiments on their own.
 
 The sim UI also includes the following navigation icons & features:
+
 **Icons**
 - Team: Click on this to chat with your team or co-facilitator live during the session
 - More Info: Click on this to read more info about the different modules and functions of the simulation user-interface
@@ -30,11 +31,11 @@ The sim UI also includes the following navigation icons & features:
 ## [Forio Epicenter Admin (mtl.how/facilitate)](https://mtl.how/facilitate)
 All co-facilitators and HQ support team members will create an Epicenter login and be added to the TeamPSD project on Epicenter. From here, co-facilitators will be able to see and have access to the Development (Dev), Test, and Production (Prod) environments of all TeamPSD tools hosted on Epicenter (mtl.how/sim, mtl.how/team, and mtl.how/demo). This platform also gives access to the underlying model files that run the simulation user-interface. However, these **are not to be changed or accessed by anyone, except the model workgroup**.
 
-Dev – This instance is for the exclusive use of the Development Team (A.K.A. “DEV”). Dev develops each sprint in this instance until they are satisfied it is ready for user testing. When iterations are completed, the sprint is promoted to PROD.
+**Dev** – This instance is for the exclusive use of the Development Team (A.K.A. “DEV”). Dev develops each sprint in this instance until they are satisfied it is ready for user testing. When iterations are completed, the sprint is promoted to PROD.
 
-Test – This instance is for the Workgroup Leads and others to conduct user testing of the current sprint. When the testing and resulting development iterations are completed, the sprint is promoted to PROD.
+**Test** – This instance is for the Workgroup Leads and others to conduct user testing of the current sprint. When the testing and resulting development iterations are completed, the sprint is promoted to PROD.
 
-Prod – This is the Production instance that is available for the *Modeling to Learn* learners to use.
+**Prod** – This is the Production instance that is available for the *Modeling to Learn* learners to use.
 (include explanation of dev, test, prod) - The underlying model files responsible for running the simulation user-interface 
 
 Through the Epicenter backend platform, users can:
@@ -44,7 +45,7 @@ Through the Epicenter backend platform, users can:
 - Manage, create, and troubleshoot team groups, worlds, and roles 
 
 
-By changing roles to a facilitator instead of a learner, you can also access the Facilitator Dashboard which includes:
+By changing roles to a facilitator instead of a learner, users can also access the Facilitator Dashboard which includes:
 - Dashboards: Click here to see a quick overview on progress of each experiment for the team, team roster, and statistics on each team experiment (i.e. time taken, attendance, etc.)
 - Community (THIS SAYS PLDR CAN WE CHANGE): Click here to see which users have contributed to the Community of Practice as well as the corresponding issue number for GitHub. Users can also manage text for the Community button, News, and Alerts. 
 - Chat: Click here to chat back with the team during a live session

--- a/sim_ui.md
+++ b/sim_ui.md
@@ -13,35 +13,45 @@ The team can choose from 5 modules: Care Coordination, Medication Management, Ps
 Using their VA email, clinicians can login to two types of environments on the simulation user-interface, or sim UI: team world and individual world. There is one team world per team which includes all members of the care team as well as the co-facilitators for making team decisions to run experiments together. There is one individual world per team member for running extra experiments on their own.
 
 The sim UI also includes the following navigation icons & features:
+**Icons**
 - Team: Click on this to chat with your team or co-facilitator live during the session
 - More Info: Click on this to read more info about the different modules and functions of the simulation user-interface
 - News: Click on this to quickly read the current news flashes on Community of Practice discussion items. This icon includes a red notification button alerting you to the number of unread messages, similar to the notification system on your phone!
 - Report Bug: Click on this to report any issues, including the option to include screenshots. No PII/PHI please!
 - Tutor: Click on this icon for an "over the shoulder" walk through of the different icons, headers, and functions across the simulation user-interface with navigation buttons. These pop-ups also include links to the TMS video and relevant session guide further detailing the section.
 - Community: Click on this floating button to contribute ideas, like something, or ask a question on the online Community of Practice. You can also further search the Community of Practice for previously answered questions or to get involved in any discussions. No PII/PHI here please!
+
+**Features**
 - Quick Tips: Anytime you're waiting for a new screen to load, a quick tip and related icon will pop-up to remind you of different functions.
+- Alerts: If we need to alert users of any urgent or sensitive news, a pop-up will flash once logged in with details.
 
 
 
-## Epicenter 
+## [Forio Epicenter Admin (mtl.how/facilitate)](https://mtl.how/facilitate)
+All co-facilitators and HQ support team members will create an Epicenter login and be added to the TeamPSD project on Epicenter. From here, co-facilitators will be able to see and have access to the Development (Dev), Test, and Production (Prod) environments of all TeamPSD tools hosted on Epicenter (mtl.how/sim, mtl.how/team, and mtl.how/demo). This platform also gives access to the underlying model files that run the simulation user-interface. However, these **are not to be changed or accessed by anyone, except the model workgroup**.
 
-- each team managed in backend
-- holds all model files
-- explain dev/test/prod
-- add learners
-- add facilitators
-- get login for new facilitator
-- team world management and naming
-- create groups & roles
-- chnage role to facilitator
-- manage end users
-- edit more info
-- edit quick tips
-- edit tutor
-- facilitator dashboard
-- pldr stuff
-- chat with team
-- 
+Dev – This instance is for the exclusive use of the Development Team (A.K.A. “DEV”). Dev develops each sprint in this instance until they are satisfied it is ready for user testing. When iterations are completed, the sprint is promoted to PROD.
+
+Test – This instance is for the Workgroup Leads and others to conduct user testing of the current sprint. When the testing and resulting development iterations are completed, the sprint is promoted to PROD.
+
+Prod – This is the Production instance that is available for the *Modeling to Learn* learners to use.
+(include explanation of dev, test, prod) - The underlying model files responsible for running the simulation user-interface 
+
+Through the Epicenter backend platform, users can:
+- Manage team data files
+- Manage permissions and add new end users
+- Add new learners and facilitators
+- Manage, create, and troubleshoot team groups, worlds, and roles 
+
+
+By changing roles to a facilitator instead of a learner, you can also access the Facilitator Dashboard which includes:
+- Dashboards: Click here to see a quick overview on progress of each experiment for the team, team roster, and statistics on each team experiment (i.e. time taken, attendance, etc.)
+- Community (THIS SAYS PLDR CAN WE CHANGE): Click here to see which users have contributed to the Community of Practice as well as the corresponding issue number for GitHub. Users can also manage text for the Community button, News, and Alerts. 
+- Chat: Click here to chat back with the team during a live session
+- More Info: Click here to add or edit text displayed in the More Info section of the sim UI.
+- Tutor: Click here to add or edit text & links displayed in the Tutor pop-ups.
+- Tips: Click here to add or edit text & icons displayed in the Quick Tips pop-ups.
+
 ## Maps
 - [Run a new experiment](add link)
 - [Add your avatar](add link)
@@ -53,9 +63,10 @@ The sim UI also includes the following navigation icons & features:
 - [Edit "More Info" content](add link)
 - [Edit "Quick Tips" content](add link)
 - [View team progress using the facilitator dashboard](add link)
+- [Add a new end user](insert link)
 
 ## Cheatsheets
 - [Simulation user-interface or sim UI cheatsheet](insert link)
 
 ## Checklists
-- [Pre-sessionpre session run through to make sure everything is working for team
+- [Pre-session review checklist](insert link)

--- a/sim_ui.md
+++ b/sim_ui.md
@@ -9,56 +9,21 @@ The *Modeling to Learn* simulation user-interface is used in *Modeling to Learn 
 
 The team can choose from 5 modules: Care Coordination, Medication Management, Psychotherapy, Aggregate Mix of Services, and Measurement Based Care and Suicide Prevention. Over the course of *MTL*, the team runs 4 scenarios relevant to their care team's operations - basecase of no new decisions, experiment 1, experiment 2, and experiment 3.
 
-## Simulation User-Interface
+## [Simulation User-Interface (mtl.how/sim)](https://mtl.how/sim)
 Using their VA email, clinicians can login to two types of environments on the simulation user-interface, or sim UI: team world and individual world. There is one team world per team which includes all members of the care team as well as the co-facilitators for making team decisions to run experiments together. There is one individual world per team member for running extra experiments on their own.
 
-The sim UI also includes the following navigation icons:
-- Chat
-- More Info
-- News
-- Report Bug
-- Tutor 
-- Community
+The sim UI also includes the following navigation icons & features:
+- Team: Click on this to chat with your team or co-facilitator live during the session
+- More Info: Click on this to read more info about the different modules and functions of the simulation user-interface
+- News: Click on this to quickly read the current news flashes on Community of Practice discussion items. This icon includes a red notification button alerting you to the number of unread messages, similar to the notification system on your phone!
+- Report Bug: Click on this to report any issues, including the option to include screenshots. No PII/PHI please!
+- Tutor: Click on this icon for an "over the shoulder" walk through of the different icons, headers, and functions across the simulation user-interface with navigation buttons. These pop-ups also include links to the TMS video and relevant session guide further detailing the section.
+- Community: Click on this floating button to contribute ideas, like something, or ask a question on the online Community of Practice. You can also further search the Community of Practice for previously answered questions or to get involved in any discussions. No PII/PHI here please!
+- Quick Tips: Anytime you're waiting for a new screen to load, a quick tip and related icon will pop-up to remind you of different functions.
 
 
-Click on the "Team" icon to chat with your team or facilitator.
 
-Click on the "More Info" icon for more info on the sim UI.
-
-Click on the "News" icon for news flashes on discussion items. Your input on discussion items in the Community of Practice is appreciated. A red pop-up with a number will appear next to this icon (similar to how text messages work on your phone) to alert you to the number of un-read news flashes. Once you read the news flashes, the red pop-up will disappear, but you can always click on "News" to review the current new flashes.
-
-Click on the "Report Bug" Icon in the top nav bar to report issues.
-
-Never include any PII/PHI in your description and screenshot.
-To include screenshots, you can:
-Copy & paste from Snipping Tool
-Drag & drop a screenshot file
-Upload your screenshot file
-Click on the "Tutor" icons for an "over the shoulder" orientation to the different icons, blue headers, and functions of each page. Each red tutor pop-up includes icons for:
-
-Video: Links to the relevant TMS video for this section.
-Guide: Links to the relevant session guide for this section.
-Back/Next: Move back or next in the tutor instructions for this section.
-Close: Close the tutor pop-up. Click on any tutor icon at any time, to get "over the shoulder" instructions for this section.
-Click on the "Community" button on the bottom right if:
-
-You have an idea
-You like something
-You have a question:
-See if someone already answered your question online in the Community of Practice.
-Set up a GitHub account to ask your question directly in the Community of Practice.
-Email your question to mtl.help@va.gov
-Never include any PII/PHI in your description and screenshot unless you are emailing mtl.help@va.gov from your VA email. The Community of Practice is a public platform. Follow established VA guidance on posting information to the public.
-To include screenshots in the "Community" button, you can:
-Copy & paste from Snipping Tool
-Drag & drop a screenshot file
-Upload your screenshot file
-
-- includes tutor function
-- includes function to chat with team or facilitator during live session
-- stay up to date with new ideas & questions posed in community of practice
-- contribute to ideas questions, in community of practice
-- submit bugs 
+## Epicenter 
 
 - each team managed in backend
 - holds all model files
@@ -78,19 +43,19 @@ Upload your screenshot file
 - chat with team
 - 
 ## Maps
-- run an experiment
-- add avatar
-- upload new file to run in sim
-- manage experiments
-- create groups/worlds and add learners
-- suppress world
-- change world to facilitator
-- edit more info
-- edit quick tips
-- anything facilitator world related
+- [Run a new experiment](add link)
+- [Add your avatar](add link)
+- [Upload a fresh team data file ](add link)
+- [Manage previously run experiments](add link)
+- [Create and manage groups and worlds](add link)
+- [Suppress a world](add link)
+- [Change roles a learner to a facilitator](add link) 
+- [Edit "More Info" content](add link)
+- [Edit "Quick Tips" content](add link)
+- [View team progress using the facilitator dashboard](add link)
 
 ## Cheatsheets
-- sim ui checklist
+- [Simulation user-interface or sim UI cheatsheet](insert link)
 
 ## Checklists
-- pre session run through to make sure everything is working for team
+- [Pre-sessionpre session run through to make sure everything is working for team


### PR DESCRIPTION
Hi all,

Following up from last week's HQ meeting and this week's Monday WG meeting, this is my draft of the sim documentation for the mtl manual.

I will obviously link all the maps and cheatsheets once I get all of those finished and posted into this branch, but thought I'd get this documentation draft checked out first. I know some of this info is in the sim, learner SEE, facilitator SAY, individual training guides, but thought it would be helpful to just have it all in one place. 

FYI: @lijenn @branscombj Looks like Debbie still hasn't accepted the invite to this lzim/mtl repo so I'm not able to ping her on these pull requests. Jenn can you help Debbie with that, as we'll continue to need her insights as we get this mtl manual finished.