### PR TITLE
See say guides adobe connect update

### DIFF
--- a/blue/session01/s01_facilitator/mtl_session01_say.md
+++ b/blue/session01/s01_facilitator/mtl_session01_say.md
@@ -30,7 +30,7 @@ Our DO for this session is to Launch _Modeling to Learn_ and select a Team Visio
 <!-- Done and Do Tables -->
 | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" height = "80" width = "80">](#DontLink) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" height = "90" width = "90">](#DontLink) **Do** |
 | --- | --- |
-|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_live_sm.png" height = "75" width = "110">](http://mtl.how/live)  We logged in to mtl.how/live for screen-sharing in the team meeting and called in to VANTS for audio. | We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed. | We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
 
 ## Learning Objectives
 
@@ -133,7 +133,7 @@ b. Now picture the team learning over the next 6 months in a *best case* scenari
 <!-- Done and Do Tables -->
 | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" height = "80" width = "80">](#DontLink) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" height = "90" width = "90">](#DontLink) **Do** |
 | --- | --- |
-|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_live_sm.png" height = "75" width = "110">](http://mtl.how/live)  We selected a Team Vision to orient our learning throughout the MTL program. We will hold this vision up as a reminder of our shared goals to orient our learning throughout MTL. | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/logos/va_team_psd_logo_sq_sm.png?raw=true" height = "75" width = "100">](mailto:mtl.help@va.gov) [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "75" width = "110">](http://mtl.how/data)  Select a team lead and email Team PSD to set up our standing team meeting time. Log into mtl.how/data to look at the splash page. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink)  We selected a Team Vision to orient our learning throughout the MTL program. We will hold this vision up as a reminder of our shared goals to orient our learning throughout MTL. | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/logos/va_team_psd_logo_sq_sm.png?raw=true" height = "75" width = "100">](mailto:mtl.help@va.gov) [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "75" width = "110">](http://mtl.how/data)  Select a team lead and email Team PSD to set up our standing team meeting time. Log into mtl.how/data to look at the splash page. |
 
 ## DO Demo
 

--- a/blue/session01/s01_facilitator/mtl_session01_say.md
+++ b/blue/session01/s01_facilitator/mtl_session01_say.md
@@ -30,7 +30,7 @@ Our DO for this session is to Launch _Modeling to Learn_ and select a Team Visio
 <!-- Done and Do Tables -->
 | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" height = "80" width = "80">](#DontLink) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" height = "90" width = "90">](#DontLink) **Do** |
 | --- | --- |
-|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed. | We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) We join the Microsoft Teams meeting invitation from Outlook and called in, if needed. | We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
 
 ## Learning Objectives
 

--- a/blue/session01/s01_learner/mtl_session01_see.md
+++ b/blue/session01/s01_learner/mtl_session01_see.md
@@ -26,7 +26,7 @@ output:
 <!-- Done and Do Table -->
 |[<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" alt = "Done" height = "80" width = "80">](#Done-and-Do) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" alt = "Do" height = "90" width = "90">](#Done-and-Do) **Do** |
 | --- | --- |
-|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed.](#Done-and-Do)| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed.]| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
 
 <!-- Learning Objectives Icon -->
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/learning_objectives.png" alt = "Learning Objectives" height = "90" width = "90" style ="display: inline-block">](#DontLink)

--- a/blue/session01/s01_learner/mtl_session01_see.md
+++ b/blue/session01/s01_learner/mtl_session01_see.md
@@ -26,7 +26,7 @@ output:
 <!-- Done and Do Table -->
 |[<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" alt = "Done" height = "80" width = "80">](#Done-and-Do) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" alt = "Do" height = "90" width = "90">](#Done-and-Do) **Do** |
 | --- | --- |
-|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed.| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) We join the Microsoft Teams meeting invitation from Outlook and called in, if needed.| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
 
 <!-- Learning Objectives Icon -->
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/learning_objectives.png" alt = "Learning Objectives" height = "90" width = "90" style ="display: inline-block">](#DontLink)

--- a/blue/session01/s01_learner/mtl_session01_see.md
+++ b/blue/session01/s01_learner/mtl_session01_see.md
@@ -26,7 +26,7 @@ output:
 <!-- Done and Do Table -->
 |[<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" alt = "Done" height = "80" width = "80">](#Done-and-Do) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" alt = "Do" height = "90" width = "90">](#Done-and-Do) **Do** |
 | --- | --- |
-|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_live_sm.png" height = "75" width = "110">](http://mtl.how/live) We logged in to mtl.how/live for screen-sharing in the team meeting and called in to VANTS for audio. [![navigate to mtl live screencast](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/mtl_2.0/mtl_live.gif)](#Done-and-Do)| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed.](#Done-and-Do)| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
 
 <!-- Learning Objectives Icon -->
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/learning_objectives.png" alt = "Learning Objectives" height = "90" width = "90" style ="display: inline-block">](#DontLink)

--- a/blue/session01/s01_learner/mtl_session01_see.md
+++ b/blue/session01/s01_learner/mtl_session01_see.md
@@ -26,7 +26,7 @@ output:
 <!-- Done and Do Table -->
 |[<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" alt = "Done" height = "80" width = "80">](#Done-and-Do) **Done** | [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" alt = "Do" height = "90" width = "90">](#Done-and-Do) **Do** |
 | --- | --- |
-|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed.]| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
+|[<img src = "https://github.com/lzim/teampsd/blob/pre_post_mtl_red_link_fix/resources/logos/ms_teams_logo.png?raw=true" height = "65" width = "70">](#DontLink) Join the Microsoft Teams meeting invitation from Outlook and call in, if needed.| We will begin _Modeling to Learn_ and select a Team Vision for _MTL_. |
 
 <!-- Learning Objectives Icon -->
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/learning_objectives.png" alt = "Learning Objectives" height = "90" width = "90" style ="display: inline-block">](#DontLink)

--- a/blue/session05/s05_facilitator/mtl_session05_say.md
+++ b/blue/session05/s05_facilitator/mtl_session05_say.md
@@ -52,13 +52,13 @@ Hello! I'm \________________ (facilitator's name) and I'm \_______________ (co-f
 
 ## In-session Exercise \[ [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/timestamp.png" height = "15" width = "15">](#DontClick) \]
 
-**The Team Lead, or whoever is willing to drive today: open an Internet Explorer browser and a Chrome browser, then share both applications in Adobe Connect.**
+**The Team Lead, or whoever is willing to drive today: open a Chrome browser, then screen-share both applications in Microsoft Teams.**
 
 ### 1. In session 3, we used our team data UI and clicked "Create Team Data Table" to produce our team data for simulation. \[ [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/timestamp.png" height = "15" width = "15">](#DontClick) \]
 
-### 2. Let's now go back to mtl.how/data in an Internet Explorer window to check the name of our team_data_table file.
+### 2. Let's now go back to mtl.how/data in the browser window to check the name of our team_data_table file.
 
-- We want to grab the filename from there so we can upload it to the sim UI. Open an Explorer browser window and go to mtl.how/data.  
+- We want to grab the filename from there so we can upload it to the sim UI. Open a browser window and go to mtl.how/data.  
 
 ### 3. The team data file for simulation is in our team folder, in the team_data_table folder. \[ [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/timestamp.png" height = "15" width = "15">](#DontClick) \]
 

--- a/blue/session05/s05_learner/mtl_session05_see.md
+++ b/blue/session05/s05_learner/mtl_session05_see.md
@@ -44,9 +44,9 @@ output:
 # Session 5 In-Session Exercise
 [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">](#DontLink)
 
-## Check the name of your team data file in Explorer.
+## Check the name of your team data file.
 1. In session 3, we used our team data UI and clicked "Create Team Data Table" to produce our team data for simulation. 
-2. Let's now go back to mtl.how/data in an Internet Explorer window to check the name of our team data file.
+2. Let's now go back to mtl.how/data in any browser window to check the name of our team data file.
 3. The team data file for simulation is in our team folder, in the team_data_sim folder. 
     + Copy the name of the team data file.
 


### PR DESCRIPTION
Updated SEE/SAY guides from Adobe Connect to Microsoft Teams and removed remaining references to using mtl.how/data only on Internet Explorer in S5. 