### PR TITLE
Session02 phi edits

### DIFF
--- a/blue/session02/s02_facilitator/mtl_session02_say.md
+++ b/blue/session02/s02_facilitator/mtl_session02_say.md
@@ -179,7 +179,7 @@ ___ | Meas| Standardized symptom scales, such as the PHQ-9 for depression or PCL
    [<img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/timestamp.png" height = "40" width = "40" style ="display: inline-block"/>](#DontLink) ***00:35-00:40***
 
 ### 7. **Click to view the "data" tabs, which show your team's individual patient information.**
-   - Patients who have requested restricted access to their information have asterisks \(\*\*\*\*\) in Column F & G. If you are a VA provider, you can still identify patients from Column H.
+   - Patients who have requested restricted access to their information have asterisks (****) in Column F (dataDiag, dataHF) or Column E (dataMeas). If you are a VA provider, you can still identify patients from Column G (dataDiag, dataHF) or Column F (dataMeas).
    - Patient information corresponds to the same categories as the team trends: diagnoses, encounters, health factor data (e.g., suicide plans, evidence-based practice templates), and measures from mental health assistant.
    - Providers can filter to find specific patients, or produce reports.
 

--- a/blue/session02/s02_learner/mtl_session02_see.md
+++ b/blue/session02/s02_learner/mtl_session02_see.md
@@ -169,7 +169,7 @@ For *MTL* 1.7 click [here](https://github.com/lzim/mtl/blob/master/release_1.7/m
 
 ### 7. Click to view the "data" tab, which show your team's individual patient information.
 
-- Patients who have requested restricted access to their information have asterisks /(/*/*/*/*/) in Columns F & G. If you are a VA provider, you can still identify patients from Column H.
+- Patients who have requested restricted access to their information have asterisks (****) in Column F (dataDiag, dataHF) or Column E (dataMeas). If you are a VA provider, you can still identify patients from Column G (dataDiag, dataHF) or Column F (dataMeas).
 - Patient information corresponds to the same categories as the team trends: diagnoses, encounters, health factor data (e.g., suicide plans, evidence-based practice templates), and measures from Mental Health Assistant.
 - Providers can filter to find specific patients, or produce reports.
 

--- a/red/part1/part1_facilitator/mtl_red_part_1_say.md
+++ b/red/part1/part1_facilitator/mtl_red_part_1_say.md
@@ -197,7 +197,7 @@ ___ | Meas| Standardized symptom scales, such as the PHQ-9 for depression or PCL
 
 ### 7. Click to view the "data" tabs, which show your team's individual patient information.
 
-- Patients who have requested restricted access to their information have asterisks (****) in Column F & G. If you are a VA provider, you can still identify patients from Column H.  
+- Patients who have requested restricted access to their information have asterisks (****) in Column F (dataDiag, dataHF) or Column E (dataMeas). If you are a VA provider, you can still identify patients from Column G (dataDiag, dataHF) or Column F (dataMeas).
 
 - Patient information corresponds to the same categories as the team trends: diagnoses, encounters, health factor data (e.g., suicide plans, evidence-based practice templates), and measures from mental health assistant.  
 

--- a/red/part1/part1_learner/mtl_red_part_1_see.md
+++ b/red/part1/part1_learner/mtl_red_part_1_see.md
@@ -133,7 +133,7 @@ output:
 
 ### 7. Click to view the "data" tab, which show your team's individual patient information.
 
-- Patients who have requested restricted access to their information have asterisks (****) in Columns F & G. If you are a VA provider, you can still identify patients from Column H.
+- Patients who have requested restricted access to their information have asterisks (****) in Column F (dataDiag, dataHF) or Column E (dataMeas). If you are a VA provider, you can still identify patients from Column G (dataDiag, dataHF) or Column F (dataMeas).
 - Patient information corresponds to the same categories as the team trends: diagnoses, encounters, health factor data (e.g., suicide plans, evidence-based practice templates), and measures from Mental Health Assistant.
 - Providers can filter to find specific patients, or produce reports.
 - dataDiag in the data UI has an additional column after "Diagnoses of Interest," called "Primary Diagnoses", specifying which diagnosis is primary.


### PR DESCRIPTION
update blue s02 and red part 1 "data" section to include the below according to the updated columns of data with removal of SSN:
"Patients who have requested restricted access to their information have asterisks (****) in Column F (dataDiag, dataHF) or Column E (dataMeas). If you are a VA provider, you can still identify patients from Column G (dataDiag, dataHF) or Column F (dataMeas)."